### PR TITLE
Fix perf issue with SavestateDrawer

### DIFF
--- a/Packages/org.plunderludics.UnityHawk/Editor/Inspector/SavestateDrawer.cs
+++ b/Packages/org.plunderludics.UnityHawk/Editor/Inspector/SavestateDrawer.cs
@@ -3,11 +3,19 @@ using UnityEditor;
 using UnityEditor.Search;
 using UnityEngine.Search;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace UnityHawk.Editor
 {
 [CustomPropertyDrawer(typeof(Savestate))]
 public class SavestateDrawer : PropertyDrawer {
+    // There is not necessarily one SavestateDrawer instance for each Savestate field so keep things in a dictionary in case
+    // (I think one instance gets created per Emulator component maybe? Not sure)
+    // This field could be static but having it per-instance is a hacky way of ensuring the cache gets invalidated more frequently
+    // TODO: this caching logic should go in a different class,
+    // and also cache should refresh when savestate assets are created or deleted
+    private Dictionary<Rom, List<Savestate>> _savestatesForRom = new ();
+
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
         // Draw the default property field
         // EditorGUI.PropertyField(position, property, label);
@@ -31,13 +39,22 @@ public class SavestateDrawer : PropertyDrawer {
         // (Shouldn't really do this every frame, but it doesn't seem to be too bad)
         // (Some roms don't get hashed, so fallback to rom filename)
         // (Some older savestates don't have rominfo at all, those will get hidden)
-        var savestates = AssetDatabase.FindAssets("t:savestate")
-            .Select(guid => AssetDatabase.LoadAssetAtPath<Savestate>(AssetDatabase.GUIDToAssetPath(guid)))
-            .Where(savestate => savestate.MatchesRom(rom));
-        
-        savestates = savestates.Prepend(null); // Add a null option to the list
-        var savestateNames = savestates.Select(savestate => savestate != null ? savestate.name : "None");
-        int currentIndex = savestates.ToList().IndexOf(property.objectReferenceValue as Savestate);
+        if (!_savestatesForRom.TryGetValue(rom, out var savestates)) {
+            Debug.Log($"No cached savestates for rom {rom.name}, searching for savestates");
+            savestates = AssetDatabase.FindAssets("t:savestate")
+                    .Select(guid => AssetDatabase.LoadAssetAtPath<Savestate>(AssetDatabase.GUIDToAssetPath(guid)))
+                    .Where(savestate => savestate.MatchesRom(rom))
+                    .ToList();
+            _savestatesForRom[rom] = savestates;
+        } else {
+            // Debug.Log($"Using cached {savestates.Count} savestates for rom {rom.name}");
+        }
+
+        var dropdownSavestates = new List<Savestate>(savestates); // Clone savestates to add null option at the beginning
+        dropdownSavestates.Insert(0, null);
+
+        var savestateNames = dropdownSavestates.Select(savestate => savestate != null ? savestate.name : "None");
+        int currentIndex = dropdownSavestates.IndexOf(property.objectReferenceValue as Savestate);
 
         // Create a dropdown menu with the savestates
         EditorGUI.BeginChangeCheck();
@@ -45,43 +62,14 @@ public class SavestateDrawer : PropertyDrawer {
         int selectedIndex = EditorGUI.Popup(popupRect, currentIndex, savestateNames.ToArray());
         if (EditorGUI.EndChangeCheck()) {
             // Set the property to the selected savestate
-            var selectedSavestate = savestates.ElementAt(selectedIndex);
+            var selectedSavestate = dropdownSavestates.ElementAt(selectedIndex);
             property.objectReferenceValue = selectedSavestate;
             property.serializedObject.ApplyModifiedProperties();
+
+            // Kinda hacky, but invalidate the cache for this rom whenever selecting an option
+            // - at least this way we can easily refresh the cache when needed
+            _savestatesForRom.Remove(rom);
         }
-
-        // ShowPicker UI:
-        // // Then draw the button
-        // var buttonRect = new Rect(position.x + position.width - buttonWidth, position.y, buttonWidth, EditorGUIUtility.singleLineHeight);
-        // if (GUI.Button(buttonRect, "⊙"))
-        // {
-        //     // Open search picker
-        //     var context = SearchService.CreateContext("t:savestate");
-
-        //     // This sucks, there's no way to pass SearchViewFlags.HideSearchBar with this method,
-        //     // and the alternative ShowPicker(ViewState) doesn't take a filterHandler argument
-        //     // Best thing is probably to implement a custom SearchProvider that does the filtering but what a pain..
-        //     // This works ok for now anyway, just annoying that the search bar is visible
-
-        //     SearchService.ShowPicker(context,
-        //         selectHandler: (SearchItem item, bool canceled) =>
-        //         {
-        //             if (canceled) return;
-        //             // Set the property to the selected savestate
-        //             property.objectReferenceValue = item?.ToObject() as Savestate;
-        //             property.serializedObject.ApplyModifiedProperties();
-        //         },
-        //         filterHandler: (SearchItem item) =>
-        //         {
-        //             // Attempt to get the Savestate object from the item's id or a custom property
-        //             var savestate = item?.ToObject() as Savestate;
-        //             // Check if the savestate belongs to the same rom
-        //             // TODO: should check hash here instead
-        //             return savestate?.RomInfo.Name == rom.name;
-        //         }
-        //     );
-        // }
-
         EditorGUI.EndProperty();
     }
 }


### PR DESCRIPTION
Cache the savestates for the current rom instead of searching every frame

I guess closes https://github.com/plunderludics/unity-hawk/issues/101, although inspector is still noticeably slow for me