### PR TITLE
v1.1.2

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,13 +1,15 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": "1.1.5",
-    "com.unity.inputsystem": "1.14.0",
-    "com.unity.test-framework": "1.1.33",
-    "com.unity.postprocessing": "3.4.0",
+    "com.codewriter.triinspector": "1.15.1",
+    "com.unity.ai.navigation": "2.0.9",
+    "com.unity.inputsystem": "1.14.2",
+    "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.postprocessing": "3.5.0",
+    "com.unity.test-framework": "1.6.0",
+    "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.audio": "1.0.0",
-    "com.unity.modules.imgui": "1.0.0",
-    "com.codewriter.triinspector": "1.15.1"
+    "com.unity.modules.imgui": "1.0.0"
   },
   "scopedRegistries": [
     {

--- a/Packages/org.plunderludics.UnityHawk/Editor/BizhawkAssets/RomImporter.cs
+++ b/Packages/org.plunderludics.UnityHawk/Editor/BizhawkAssets/RomImporter.cs
@@ -53,33 +53,39 @@ internal class RomImporter : BizHawkAssetImporter<Rom>
         base.OnImportAsset(ctx);
 
         Rom rom = ctx.mainObject as Rom;
+        rom.Hash = TryComputeHash(ctx.assetPath);
+    }
 
-        // Very rough approximation of what BizHawk does in RomLoader.cs to determine how to take the hash
-        string path = ctx.assetPath;
-        string ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
-        if (Disc.IsValidExtension(ext)) {
-            // Treat as disc
+    static string TryComputeHash(string assetPath) {
+        try {
+            // Very rough approximation of what BizHawk does in RomLoader.cs to determine how to take the hash
+            string ext = System.IO.Path.GetExtension(assetPath).ToLowerInvariant();
+            if (Disc.IsValidExtension(ext)) {
+                // Treat as disc
 
-            // Below doesn't work for weird dll reasons so give up
-            rom.Hash = null;
-            // var disc = DiscExtensions.CreateAnyType(path, str => Debug.LogError(str));
-            // if (disc == null) {
-            //     Debug.LogError($"Failed to load disc image {path}");
-            // 	rom.Hash = null;
-            // } else {
-            // 	var discType = new DiscIdentifier(disc).DetectDiscType();
-            // 	var discHasher = new DiscHasher(disc);
-            // 	var discHash = discType == DiscType.SonyPSX
-            // 		? discHasher.Calculate_PSX_BizIDHash()
-            // 		: discHasher.OldHash();
-                
-            // 	rom.Hash = discHash;
-        } else {
-            // Treat as regular ROM
-            // Assume SHA1 for now - actual implementation tries multiple hashes so it's complicated
-            byte[] romData = System.IO.File.ReadAllBytes(path);
-
-            rom.Hash = SHA1.Create().ComputeHash(romData).BytesToHexString();
+                // Below doesn't work for weird dll reasons so give up
+                return null;
+                // var disc = DiscExtensions.CreateAnyType(assetPath, str => Debug.LogError(str));
+                // if (disc == null) {
+                //     Debug.LogError($"Failed to load disc image {assetPath}");
+                // 	return null;
+                // } else {
+                // 	var discType = new DiscIdentifier(disc).DetectDiscType();
+                // 	var discHasher = new DiscHasher(disc);
+                // 	var discHash = discType == DiscType.SonyPSX
+                // 		? discHasher.Calculate_PSX_BizIDHash()
+                // 		: discHasher.OldHash();
+                    
+                // 	return discHash;
+            } else {
+                // Treat as regular ROM
+                // Assume SHA1 for now - actual implementation tries multiple hashes so it's complicated
+                byte[] romData = System.IO.File.ReadAllBytes(assetPath);
+                return SHA1.Create().ComputeHash(romData).BytesToHexString();
+            }
+        } catch (System.Exception e) {
+            Debug.LogWarning($"Failed to compute hash for ROM '{assetPath}': {e.Message}");
+            return null;
         }
     }
 }

--- a/Packages/org.plunderludics.UnityHawk/Editor/BizhawkAssets/SavestateImporter.cs
+++ b/Packages/org.plunderludics.UnityHawk/Editor/BizhawkAssets/SavestateImporter.cs
@@ -15,46 +15,76 @@ internal class SavestateImporter : BizHawkAssetImporter<Savestate> {
 
     public override void OnImportAsset(AssetImportContext ctx) {
         base.OnImportAsset(ctx);
-        var savestate = (Savestate)ctx.mainObject;
+        try {
+            var savestate = (Savestate)ctx.mainObject;
+            using var stateFile = ZipFile.OpenRead(ctx.assetPath);
 
-        using var stateFile = ZipFile.OpenRead(ctx.assetPath);
-        var gameInfo = GameInfo.NullInstance;
-        Texture2D screenshot = null;
-        // find the game info file and deserialize it
-        foreach (var entry in stateFile.Entries) {
-            if (entry.Name == k_GameInfoFile) {
-                using var s = entry.Open();
-                gameInfo = GameInfo.Deserialize(s) ?? GameInfo.NullInstance;
-            } else if (entry.Name == k_FramebufferFile) {
-                using var s = entry.Open();
-                using var bmpStream = new DecompressionStream(s);
+            var gameInfo = GameInfo.NullInstance;
+            Texture2D screenshot = null;
 
-                // First read all bytes from stream
-                byte[] bmpBytes;
-                using (var ms = new MemoryStream())
-                {
-                    bmpStream.CopyTo(ms);
-                    bmpBytes = ms.ToArray();
+            foreach (var entry in stateFile.Entries) {
+                if (entry.Name == k_GameInfoFile) {
+                    gameInfo = TryImportGameInfo(entry, ctx.assetPath);
+                } else if (entry.Name == k_FramebufferFile) {
+                    screenshot = TryImportScreenshot(entry, ctx.assetPath);
                 }
-
-                BMPLoader bmpLoader = new BMPLoader();
-                BMPImage bmpImg = bmpLoader.LoadBMP(bmpBytes);
-
-                // Convert the Color32 array into a Texture2D
-                screenshot = bmpImg.ToTexture2D(TextureFormat.RGB24); // Ensure no alpha channel
             }
+
+            savestate.RomInfo.Name = gameInfo.Name;
+            savestate.RomInfo.Hash = gameInfo.Hash;
+            savestate.RomInfo.Region = gameInfo.Region;
+            savestate.RomInfo.System = gameInfo.System;
+            savestate.RomInfo.NotInDatabase = gameInfo.NotInDatabase;
+            savestate.RomInfo.Core = gameInfo.ForcedCore;
+
+            if (screenshot != null) {
+                screenshot.name = Path.GetFileNameWithoutExtension(ctx.assetPath);
+                ctx.AddObjectToAsset("screenshot", screenshot);
+                savestate.Screenshot = screenshot;
+            }
+        } catch (System.Exception e) {
+            Debug.LogWarning($"Failed to import savestate content from '{ctx.assetPath}': {e.Message}");
         }
+    }
 
-        savestate.RomInfo.Name = gameInfo.Name;
-        savestate.RomInfo.Hash = gameInfo.Hash;
-        savestate.RomInfo.Region = gameInfo.Region;
-        savestate.RomInfo.System = gameInfo.System;
-        savestate.RomInfo.NotInDatabase = gameInfo.NotInDatabase;
-        savestate.RomInfo.Core = gameInfo.ForcedCore;
+    static GameInfo TryImportGameInfo(ZipArchiveEntry entry, string assetPath) {
+        try {
+            using var s = entry.Open();
+            return GameInfo.Deserialize(s) ?? GameInfo.NullInstance;
+        } catch (System.Exception e) {
+            Debug.LogWarning($"Failed to import GameInfo from '{assetPath}': {e.Message}");
+            return GameInfo.NullInstance;
+        }
+    }
 
-        screenshot.name = Path.GetFileNameWithoutExtension(ctx.assetPath);
-        ctx.AddObjectToAsset("screenshot", screenshot);
-        savestate.Screenshot = screenshot;
+    static Texture2D TryImportScreenshot(ZipArchiveEntry entry, string assetPath) {
+        try {
+            using var s = entry.Open();
+
+            byte[] rawBytes;
+            using (var ms = new MemoryStream()) {
+                s.CopyTo(ms);
+                rawBytes = ms.ToArray();
+            }
+
+            // Seems like sometimes (maybe in bizhawk 2.11 only?) the framebuffer file is *not* compressed - handle both cases
+            byte[] bmpBytes;
+            try {
+                using var compressed = new MemoryStream(rawBytes);
+                using var zstd = new DecompressionStream(compressed);
+                using var decompressed = new MemoryStream();
+                zstd.CopyTo(decompressed);
+                bmpBytes = decompressed.ToArray();
+            } catch (ZstdException) {
+                bmpBytes = rawBytes;
+            }
+
+            var bmpImg = new BMPLoader().LoadBMP(bmpBytes);
+            return bmpImg.ToTexture2D(TextureFormat.RGB24);
+        } catch (System.Exception e) {
+            Debug.LogWarning($"Failed to import screenshot from '{assetPath}': {e.Message}");
+            return null;
+        }
     }
 }
 

--- a/Packages/org.plunderludics.UnityHawk/Editor/EmulatorDragDropHandler.cs
+++ b/Packages/org.plunderludics.UnityHawk/Editor/EmulatorDragDropHandler.cs
@@ -1,82 +1,73 @@
 using UnityEngine;
 using UnityEditor;
+#if UNITY_6000_3_OR_NEWER
+using UnityEntityId = UnityEngine.EntityId;
+#else
+using UnityEntityId = System.Int32;
+#endif
 
 namespace UnityHawk.Editor {
 
 [InitializeOnLoad]
 internal static class EmulatorDragDropHandler {
     static EmulatorDragDropHandler() {
-        // Register for drag and drop events in the hierarchy
+#if UNITY_6000_3_OR_NEWER
+        DragAndDrop.AddDropHandlerV2(HierarchyDropHandler);
+#else
         DragAndDrop.AddDropHandler(HierarchyDropHandler);
+#endif
     }
-    
-    static DragAndDropVisualMode HierarchyDropHandler(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects, bool perform) {
-        // Debug.Log($"HierarchyDropHandler: {dropTargetInstanceID}, {dropMode}, {parentForDraggedObjects}, {perform}");
-        // Only handle exactly one dragged object
-        if (DragAndDrop.objectReferences.Length != 1) return DragAndDropVisualMode.None;
-        
-        if ((dropMode & HierarchyDropFlags.DropUpon) == 0) {
-            // Only handle dragging directly onto an object
-            return DragAndDropVisualMode.None;
-        }
 
-        // Check if we're dragging Rom or Savestate assets
-        bool hasValidAsset = false;
+    static DragAndDropVisualMode HierarchyDropHandler(
+        UnityEntityId dropTargetEntityId,
+        HierarchyDropFlags dropMode,
+        Transform parentForDraggedObjects,
+        bool perform) {
+        if (DragAndDrop.objectReferences.Length != 1) return DragAndDropVisualMode.None;
+
+        if ((dropMode & HierarchyDropFlags.DropUpon) == 0)
+            return DragAndDropVisualMode.None;
+
         Rom romAsset = null;
         Savestate savestateAsset = null;
-        
+
         foreach (Object draggedObject in DragAndDrop.objectReferences) {
-            // Debug.Log($"draggedObject: {draggedObject}");
             if (draggedObject is Rom rom) {
-                hasValidAsset = true;
                 romAsset = rom;
                 break;
-            } else if (draggedObject is Savestate savestate) {
-                hasValidAsset = true;
+            }
+            if (draggedObject is Savestate savestate) {
                 savestateAsset = savestate;
                 break;
             }
         }
-        
-        if (!hasValidAsset) return DragAndDropVisualMode.None;
-        
-        // Get the GameObject at this hierarchy item
-        GameObject gameObject = EditorUtility.InstanceIDToObject(dropTargetInstanceID) as GameObject;
+
+        if (romAsset == null && savestateAsset == null) return DragAndDropVisualMode.None;
+
+#if UNITY_6000_3_OR_NEWER
+        GameObject gameObject = EditorUtility.EntityIdToObject(dropTargetEntityId) as GameObject;
+#else
+        GameObject gameObject = EditorUtility.InstanceIDToObject(dropTargetEntityId) as GameObject;
+#endif
         if (gameObject == null) return DragAndDropVisualMode.None;
-        
-        // Check if this GameObject has an Emulator component
+
         Emulator emulator = gameObject.GetComponent<Emulator>();
-        // Debug.Log($"emulator: {emulator}");
         if (emulator == null) return DragAndDropVisualMode.None;
-        
-        // Show that this is a valid drop target
-        if (!perform) {
-            return DragAndDropVisualMode.Copy;
-        }
-        
-        // Perform the drop
+
+        if (!perform) return DragAndDropVisualMode.Copy;
+
         if (romAsset != null) {
             emulator.romFile = romAsset;
-
-            if (emulator.autoSelectRomFile && !emulator.saveStateFile.MatchesRom(romAsset)) {
-                // Need to clear savestateFile so romFile doesn't get overwritten
+            if (emulator.autoSelectRomFile && !emulator.saveStateFile.MatchesRom(romAsset))
                 emulator.saveStateFile = null;
-            }
-            
-            // Debug.Log($"Rom asset '{romAsset.name}' assigned to Emulator on '{gameObject.name}'");
-        } else if (savestateAsset != null) {
-            // Assign the Savestate to the Emulator
+        } else {
             emulator.saveStateFile = savestateAsset;
-
-            // Debug.Log($"Savestate asset '{savestateAsset.name}' assigned to Emulator on '{gameObject.name}'");
         }
 
-        // Mark the scene as dirty so Unity saves the change
         EditorUtility.SetDirty(gameObject);
         EditorUtility.SetDirty(emulator);
+        emulator.OnValidate();
 
-        emulator.OnValidate(); // A bit hacky but this doesn't get called automatically
-        
         return DragAndDropVisualMode.Copy;
     }
 }

--- a/Packages/org.plunderludics.UnityHawk/Runtime/BuildProcessing.cs
+++ b/Packages/org.plunderludics.UnityHawk/Runtime/BuildProcessing.cs
@@ -118,7 +118,6 @@ public class BuildProcessing : IPreprocessBuildWithReport, IProcessSceneWithRepo
     /// returns the number of files copied
     int CopyFilesToBuild(string exePath) {
         var bizhawkAssetsPath = GetBizhawkAssetsDir(exePath);
-        Directory.CreateDirectory(bizhawkAssetsPath);
 
         int nFilesCopied = 0;
 

--- a/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.Api.cs
+++ b/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.Api.cs
@@ -324,7 +324,9 @@ public partial class Emulator {
         // Need to update texture buffer size in case platform has changed:
         _sharedTextureBuffer.UpdateSize();
 
-        CurrentStatus = Status.Started; // Not running until new texture buffer is set up
+        // Not running until all shared buffers are set up and OnRomLoaded has been received
+        _romLoaded = false;
+        CurrentStatus = Status.Started;
     }
 
     /// <summary>

--- a/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
+++ b/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
@@ -354,7 +354,7 @@ public partial class Emulator : MonoBehaviour {
                 // _logger.LogWarning("Emulator audio cannot be captured in edit mode");
             }
             if (Application.isPlaying) {
-                audioResampler.Init(BizhawkSampleRate/AudioSettings.outputSampleRate, _logger);
+                audioResampler.Init((speedPercent/100.0)*BizhawkSampleRate/AudioSettings.outputSampleRate, _logger);
                 var audioSource = GetComponent<AudioSource>();
                 // TODO: Would be nice if we could support an audio source on a different game object
                 // But that would require moving OnFilterAudioRead into a separate "EmulatorAudio" component I guess

--- a/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
+++ b/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
@@ -72,6 +72,9 @@ public partial class Emulator : MonoBehaviour {
     /// the system ID of the current core (e.g. "N64", "PSX", etc.)
     string _systemId;
 
+    /// whether the OnRomLoaded message has been received from bizhawk
+    bool _romLoaded;
+
     /// Helper method to check if the emulator process is alive
     bool IsEmuHawkProcessAlive {
         get {
@@ -461,6 +464,7 @@ public partial class Emulator : MonoBehaviour {
         _currentBizhawkArgs = MakeBizhawkArgs();
 
         _systemId = null;
+        _romLoaded = false;
 
         // If using referenced assets then first map those assets to filenames
         // (Bizhawk requires a path to a real file on disk)
@@ -736,8 +740,8 @@ public partial class Emulator : MonoBehaviour {
         }
 
         // Consider the emulator to be running if all buffers have been opened successfully
-        // (Which means api calls, input, & texture+audio sharing should all be working)
-        if (CurrentStatus == Status.Started && allBuffersOpen) {
+        // AND the OnRomLoaded message has been received (so _systemId is guaranteed to be set before OnRunning fires)
+        if (CurrentStatus == Status.Started && allBuffersOpen && _romLoaded) {
             CurrentStatus = Status.Running;
         }
 
@@ -951,6 +955,7 @@ public partial class Emulator : MonoBehaviour {
                 case SpecialCommands.OnRomLoaded:
                     // args: $"{systemID}"
                     _systemId = argString;
+                    _romLoaded = true;
                     break;
                 default:
                     _logger.LogWarning($"Bizhawk tried to call unknown special method {callbackName}");

--- a/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
+++ b/Packages/org.plunderludics.UnityHawk/Runtime/Emulator/Emulator.cs
@@ -167,8 +167,8 @@ public partial class Emulator : MonoBehaviour {
     public Logger Logger => _logger ??= new(this, logLevel);
 
     /// the time the emulator started running
-    float _startedTime;
-    float SystemTime => (float)System.DateTime.Now.Ticks / System.TimeSpan.TicksPerSecond;
+    double _startedTime;
+    double SystemTime => System.DateTime.Now.Ticks / (double)System.TimeSpan.TicksPerSecond;
 
     /// for actions deferred to main thread Update call
     /// (used to make sure OnStarted and OnRunning actions get invoked on main thread)
@@ -697,7 +697,7 @@ public partial class Emulator : MonoBehaviour {
             IntPtr bizhawkWindow = _emuhawk.MainWindowHandle;
             IntPtr focusedWindow = GetForegroundWindow();
             if (focusedWindow != unityWindow) {
-                // _logger.LogVerbose("refocusing unity window");
+                // _logger.Log($"refocusing unity window (systemtime: {SystemTime}, startedTime: {_startedTime}, runtime: {SystemTime - _startedTime})");
                 ShowWindow(unityWindow, 5);
                 SetForegroundWindow(unityWindow);
             }

--- a/Packages/org.plunderludics.UnityHawk/Tests/Shared/SharedTestsCore.cs
+++ b/Packages/org.plunderludics.UnityHawk/Tests/Shared/SharedTestsCore.cs
@@ -55,14 +55,16 @@ public class SharedTestsCore
         // - Emulator with swoop rom and no savestate, on a disabled game object
         // - SharedTestAssets with other needed assets
 
-        SharedTestAssets assets = Object.FindObjectOfType<SharedTestAssets>();
+        SharedTestAssets assets = Object.FindAnyObjectByType<SharedTestAssets>();
+        Assert.IsNotNull(assets, "SharedTestAssets not found in scene");
         swoopRom = assets.swoopRom;
         eliteSavestate2000 = assets.eliteSavestate2000;
         eliteSavestate5000 = assets.eliteSavestate5000;
         testCallbacksLua = assets.testCallbacksLua;
 
         // Set up Emulator object
-        e = Object.FindObjectOfType<Emulator>(includeInactive: true);
+        e = Object.FindAnyObjectByType<Emulator>(FindObjectsInactive.Include);
+        Assert.IsNotNull(e, "Emulator not found in scene");
         SetParamsOnEmulator(e);
     }
 
@@ -100,9 +102,13 @@ public class SharedTestsCore
         if (Application.isPlaying) {
             SceneManager.LoadScene(sceneName);
             yield return null; // Wait for scene to load
-            if (SceneManager.GetActiveScene().name != sceneName) {
+            var scene = SceneManager.GetSceneByName(sceneName);
+            if (!scene.IsValid()) {
                 Debug.LogError($"[unity-hawk] Test scene failed to load - probably needs to be included in build settings");
             }
+
+            Assert.IsTrue(scene.IsValid());
+            Assert.IsTrue(scene.isLoaded);
         } else {
 #if UNITY_EDITOR
             // Have to load by full path

--- a/Packages/org.plunderludics.UnityHawk/package.json
+++ b/Packages/org.plunderludics.UnityHawk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "org.plunderludics.unityhawk",
-  "version": "1.1.1",
+  "version": "1.1.2",
+  "unity": "6000.4",
   "displayName": "UnityHawk",
   "description": "Run emulated games within Unity via BizHawk",
   "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,21 +10,23 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.addressables": {
-      "version": "1.22.3",
+      "version": "2.7.3",
       "depth": 2,
       "source": "registry",
       "dependencies": {
+        "com.unity.profiling.core": "1.0.2",
+        "com.unity.test-framework": "1.4.5",
         "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.scriptablebuildpipeline": "1.21.25",
+        "com.unity.scriptablebuildpipeline": "2.4.2",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ai.navigation": {
-      "version": "1.1.5",
+      "version": "2.0.9",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -33,14 +35,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.6",
+      "version": "2.0.5",
       "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.inputsystem": {
-      "version": "1.14.0",
+      "version": "1.14.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -49,14 +50,22 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.localization": {
-      "version": "1.5.2",
+      "version": "1.5.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.addressables": "1.21.9",
+        "com.unity.addressables": "1.22.2",
         "com.unity.nuget.newtonsoft-json": "3.0.2"
       },
       "url": "https://packages.unity.com"
+    },
+    "com.unity.multiplayer.center": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      }
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.2.1",
@@ -66,7 +75,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.postprocessing": {
-      "version": "3.4.0",
+      "version": "3.5.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -74,23 +83,32 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.scriptablebuildpipeline": {
-      "version": "1.21.25",
+    "com.unity.profiling.core": {
+      "version": "1.0.2",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.test-framework": {
-      "version": "1.1.33",
-      "depth": 0,
+    "com.unity.scriptablebuildpipeline": {
+      "version": "2.4.2",
+      "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.6",
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
+        "com.unity.test-framework": "1.4.5",
+        "com.unity.modules.assetbundle": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.6.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.ext.nunit": "2.0.3",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
     },
     "org.plunderludics.unityhawk": {
       "version": "file:org.plunderludics.UnityHawk",
@@ -100,6 +118,12 @@
         "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.codewriter.triinspector": "1.15.1"
       }
+    },
+    "com.unity.modules.accessibility": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",
@@ -122,6 +146,12 @@
     "com.unity.modules.audio": {
       "version": "1.0.0",
       "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.hierarchycore": {
+      "version": "1.0.0",
+      "depth": 2,
       "source": "builtin",
       "dependencies": {}
     },
@@ -162,7 +192,9 @@
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.hierarchycore": "1.0.0",
+        "com.unity.modules.physics": "1.0.0"
       }
     },
     "com.unity.modules.unitywebrequest": {

--- a/bin/run_editmode_tests.sh
+++ b/bin/run_editmode_tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Usage: ./bin/run_editmode_tests.sh
+
+: "${UNITY_VERSION:=$(grep '^m_EditorVersion:' ProjectSettings/ProjectVersion.txt | awk '{print $2}')}"
+: "${UNITY_EXE:=/c/Program Files/Unity/Hub/Editor/${UNITY_VERSION}/Editor/Unity.exe}"
+
+cmd="\"${UNITY_EXE}\"
+  -runTests \
+  -batchmode \
+  $@ \
+  -projectPath ."
+
+echo "Running EditMode tests..."
+
+mkdir -p artifacts
+> artifacts/test_log_editmode.txt
+tail -f artifacts/test_log_editmode.txt | grep "\[unity-hawk\] \[test\]" &
+TAIL_PID=$!
+
+cmd2="${cmd} -testPlatform EditMode -testResults artifacts/test_results_editmode.xml -logFile artifacts/test_log_editmode.txt"
+eval $cmd2
+EXIT_CODE=$?
+kill $TAIL_PID
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "❌ EditMode tests failed."
+    exit $EXIT_CODE
+else
+    # Double check XML just in case exit code isn't reliable
+    if grep -q 'result="Failed"' artifacts/test_results_editmode.xml; then
+        echo "❌ EditMode tests failed. Check artifacts/test_results_editmode.xml for details."
+        exit 1
+    else
+        echo "✅ EditMode tests passed."
+        exit 0
+    fi
+fi

--- a/bin/run_playmode_tests.sh
+++ b/bin/run_playmode_tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Usage: ./bin/run_playmode_tests.sh
+
+: "${UNITY_VERSION:=$(grep '^m_EditorVersion:' ProjectSettings/ProjectVersion.txt | awk '{print $2}')}"
+: "${UNITY_EXE:=/c/Program Files/Unity/Hub/Editor/${UNITY_VERSION}/Editor/Unity.exe}"
+
+cmd="\"${UNITY_EXE}\"
+  -runTests \
+  -batchmode \
+  $@ \
+  -projectPath ."
+
+echo "Running PlayMode tests..."
+
+mkdir -p artifacts
+> artifacts/test_log_playmode.txt
+tail -f artifacts/test_log_playmode.txt | grep "\[unity-hawk\] \[test\]" &
+TAIL_PID=$!
+
+cmd2="${cmd} -testPlatform PlayMode -testResults artifacts/test_results_playmode.xml -logFile artifacts/test_log_playmode.txt"
+eval $cmd2
+EXIT_CODE=$?
+kill $TAIL_PID
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "❌ PlayMode tests failed."
+    exit $EXIT_CODE
+else
+    if grep -q 'result="Failed"' artifacts/test_results_playmode.xml 2>/dev/null; then
+        echo "❌ PlayMode tests failed. Check artifacts/test_results_playmode.xml for details."
+        exit 1
+    else
+        echo "✅ PlayMode tests passed."
+        exit 0
+    fi
+fi

--- a/bin/run_standalone_tests.sh
+++ b/bin/run_standalone_tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Usage: ./bin/run_standalone_tests.sh
+
+: "${UNITY_VERSION:=$(grep '^m_EditorVersion:' ProjectSettings/ProjectVersion.txt | awk '{print $2}')}"
+: "${UNITY_EXE:=/c/Program Files/Unity/Hub/Editor/${UNITY_VERSION}/Editor/Unity.exe}"
+
+cmd="\"${UNITY_EXE}\"
+  -runTests \
+  -batchmode \
+  $@ \
+  -projectPath ."
+
+echo "Running Standalone (win64) tests..."
+echo "(No console output for these while running, but errors will be reported if it fails)"
+
+mkdir -p artifacts
+> artifacts/test_log_standalonewindows64.txt
+
+cmd3="${cmd} -testPlatform StandaloneWindows64 -testResults artifacts/test_results_standalonewindows64.xml -logFile artifacts/test_log_standalonewindows64.txt"
+eval $cmd3
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "❌ Standalone tests failed to build or run."
+    echo "---- Last 50 lines of log (artifacts/test_log_standalonewindows64.txt): ----"
+    tail -n 50 artifacts/test_log_standalonewindows64.txt
+    echo "----------------------------------------------------------------------------"
+    exit $EXIT_CODE
+else
+    if grep -q 'result="Failed"' artifacts/test_results_standalonewindows64.xml 2>/dev/null; then
+        echo "❌ Standalone tests failed. Check artifacts/test_results_standalonewindows64.xml for details."
+        # If tests natively failed, let's also dump the failures from XML if possible
+        grep -B 2 -A 5 'result="Failed"' artifacts/test_results_standalonewindows64.xml
+        exit 1
+    else
+        echo "✅ Standalone tests passed."
+        exit 0
+    fi
+fi

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,40 +1,54 @@
+#!/bin/bash
 # Usage: ./bin/run_tests.sh
 
 # Heads up - the TestRamXXX tests seem to be flaky when run from this script, sometimes fail, but they seem fine when run from editor, not sure why 
 
-: "${UNITY_VERSION:=$(grep '^m_EditorVersion:' ProjectSettings/ProjectVersion.txt | awk '{print $2}')}"
-: "${UNITY_EXE:=/c/Program Files/Unity/Hub/Editor/${UNITY_VERSION}/Editor/Unity.exe}"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cmd="\"${UNITY_EXE}\"
-  -runTests \
-  -batchmode \
-  -projectPath ."
+echo "=== Running All Tests ==="
 
-echo "Running EditMode tests"
+bash "$SCRIPT_DIR/run_editmode_tests.sh"
+EDITMODE_EXIT=$?
 
-# (Seems like we can't redirect logs to stdout so just write to file and tail -f)
-mkdir -p artifacts
-> artifacts/test_log_editmode.txt
-tail -f artifacts/test_log_editmode.txt | grep "\[unity-hawk\] \[test\]" &
-TAIL_PID=$!
+bash "$SCRIPT_DIR/run_playmode_tests.sh"
+PLAYMODE_EXIT=$?
 
-cmd2="${cmd} -testPlatform EditMode -testResults artifacts/test_results_editmode.xml -logFile artifacts/test_log_editmode.txt"
-eval $cmd2
-kill $TAIL_PID
+bash "$SCRIPT_DIR/run_standalone_tests.sh"
+STANDALONE_EXIT=$?
 
-echo "Running PlayMode tests"
+echo ""
+echo "=== Test Summary ==="
 
-> artifacts/test_log_playmode.txt
-tail -f artifacts/test_log_playmode.txt | grep "\[unity-hawk\] \[test\]" &
-TAIL_PID=$!
+FAILED=0
 
-cmd2="${cmd} -testPlatform PlayMode -testResults artifacts/test_results_playmode.xml -logFile artifacts/test_log_playmode.txt"
-eval $cmd2
-kill $TAIL_PID
+if [ $EDITMODE_EXIT -eq 0 ]; then
+    echo "✅ EditMode tests passed."
+else
+    echo "❌ EditMode tests failed."
+    FAILED=1
+fi
 
-# For some reason nothing gets logged from standalone player when running from cli - fine, can just check the xml or run from editor
-echo "Running standalone (win64) tests (no console output for these)"
-cmd3="${cmd} -testPlatform StandaloneWindows64 -testResults artifacts/test_results_standalonewindows64.xml -logFile artifacts/test_log_standalonewindows64.txt"
-eval $cmd3
+if [ $PLAYMODE_EXIT -eq 0 ]; then
+    echo "✅ PlayMode tests passed."
+else
+    echo "❌ PlayMode tests failed."
+    FAILED=1
+fi
 
-echo "Tests complete"
+if [ $STANDALONE_EXIT -eq 0 ]; then
+    echo "✅ Standalone tests passed."
+else
+    echo "❌ Standalone tests failed."
+    FAILED=1
+fi
+
+echo "===================="
+
+if [ $FAILED -ne 0 ]; then
+    # echo "❌ Some sets of tests failed."
+    exit 1
+else
+    echo "✅ All tests passed successfully."
+    exit 0
+fi
+


### PR DESCRIPTION
- #171 Fix bug causing the whole hierarchy to be unusable in Unity 6.4+
- #161 Fix race condition causing default controls to sometimes fail (This was supposed to be in the previous release but somehow didn't make it in)
- #165 Don't crash when non-essential asset content (e.g. savestate screenshot) fails to import
- #169 Don't create BizhawkAssets directory in build unless necessary
- #167 Clean up test scripts and make pass/fail result clearer
- Fix bug causing auxiliary unity editor windows to sometimes get force-closed by unityhawk in playmode (479453f5)
- Fix choppy audio on startup when speedpercent != 100 (a57f5624)